### PR TITLE
Simplify generated modules

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -6,12 +6,12 @@ yeter::queries! {
 
 fn main() {
     let mut db = yeter::Database::new();
-    db.register::<_, string::len::Query>(|_db, name| {
+    db.register::<_, string::len>(|_db, name| {
         dbg!(name.len())
     });
-    let len1 = string::len::query(&db, "hello".into());
-    let len2 = string::len::query(&db, "hello".into());
-    let len3 = string::len::query(&db, "world".into());
+    let len1 = string::len(&db, "hello".into());
+    let len2 = string::len(&db, "hello".into());
+    let len3 = string::len(&db, "world".into());
     assert_eq!(len1, len2);
     assert_eq!(len1, len3);
 }

--- a/examples/effects.rs
+++ b/examples/effects.rs
@@ -6,21 +6,21 @@ yeter::queries! {
 
 fn main() {
     let mut db = yeter::Database::new();
-    db.register::<_, string::len::Query>(|db, name| {
+    db.register::<_, string::len>(|db, name| {
         if name.len() == 0 {
             db.do_effect("An empty string was passed");
         }
         dbg!(name.len())
     });
-    let len1 = string::len::query(&db, "".into());
+    let len1 = string::len(&db, "".into());
     for msg in db.effect::<&'static str>() {
         println!("EFFECT [1]: {}", msg);
     }
-    let len2 = string::len::query(&db, "".into());
+    let len2 = string::len(&db, "".into());
     for msg in db.effect::<&'static str>() {
         println!("EFFECT [2]: {}", msg);
     }
-    let len3 = string::len::query(&db, "aaaa".into());
+    let len3 = string::len(&db, "aaaa".into());
     for msg in db.effect::<&'static str>() {
         println!("EFFECT [3]: {}", msg);
     }

--- a/examples/invalidation.rs
+++ b/examples/invalidation.rs
@@ -5,16 +5,16 @@ query!(sum, (), usize);
 
 fn main() {
     let mut db = yeter::Database::new();
-    db.register::<_, list::Query>(|_db, ()| {
+    db.register::<_, list>(|_db, ()| {
         vec![1, 2, 3]
     });
-    db.register::<_, sum::Query>(|db, ()| {
-        list::query(db, ()).iter().sum()
+    db.register::<_, sum>(|db, ()| {
+        list(db, ()).iter().sum()
     });
-    assert_eq!(*sum::query(&db, ()), 6);
+    assert_eq!(*sum(&db, ()), 6);
 
-    db.register::<_, list::Query>(|_db, ()| {
+    db.register::<_, list>(|_db, ()| {
         vec![]
     });
-    assert_eq!(*sum::query(&db, ()), 0);
+    assert_eq!(*sum(&db, ()), 0);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,20 +234,19 @@ impl Database {
 #[macro_export]
 macro_rules! query {
     ($name:ident, $i:ty, $o:ty) => {
-        pub mod $name {
-            #[allow(non_camel_case_types)]
-            pub struct Query;
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        pub struct $name {}
 
-            impl yeter::QueryDef for Query {
-                const PATH: &'static str = stringify!($name);
-                type Input = $i;
-                type Output = $o;
-            }
+        impl yeter::QueryDef for $name {
+            const PATH: &'static str = stringify!($name);
+            type Input = $i;
+            type Output = $o;
+        }
 
-            pub fn query(db: &yeter::Database, i: $i) -> std::rc::Rc<$o> {
-                use yeter::QueryDef;
-                db.run::<$i, $o>(Query::PATH, i)
-            }
+        pub fn $name(db: &yeter::Database, i: $i) -> std::rc::Rc<$o> {
+            use yeter::QueryDef;
+            db.run::<$i, $o>($name::PATH, i)
         }
     };
 }
@@ -270,20 +269,19 @@ macro_rules! query {
 #[macro_export]
 macro_rules! queries {
     ($m:expr, $name:ident, $i:ty, $o:ty) => {
-        pub mod $name {
-            #[allow(non_camel_case_types)]
-            pub struct Query;
+        #[allow(non_camel_case_types)]
+        #[doc(hidden)]
+        pub struct $name {}
 
-            impl yeter::QueryDef for Query {
-                const PATH: &'static str = concat!($m, "/", stringify!($name));
-                type Input = $i;
-                type Output = $o;
-            }
+        impl yeter::QueryDef for $name {
+            const PATH: &'static str = concat!($m, "/", stringify!($name));
+            type Input = $i;
+            type Output = $o;
+        }
 
-            pub fn query(db: &yeter::Database, i: $i) -> std::rc::Rc<$o> {
-                use yeter::QueryDef;
-                db.run::<$i, $o>(Query::PATH, i)
-            }
+        pub fn $name(db: &yeter::Database, i: $i) -> std::rc::Rc<$o> {
+            use yeter::QueryDef;
+            db.run::<$i, $o>($name::PATH, i)
         }
     };
     ($mname:ident {


### PR DESCRIPTION
Currently, queries are being generated as
```rs
// Registering
db.register::<_, path::to::my_query::Query>(...);

// Using
path::to::my_query::query(...)
```

This PR simplifies the generated modules to
```rs
// Registering
db.register::<_, path::to::my_query>(...);

// Using
path::to::my_query(...)
```

Here, we only use `path::to::my_query`. This works by defining the query function and the (formerly named) `Query` type with the same name. This is possible because in Rust, types and values are in different namespaces[^ns].

Notes:
  * Obviously, this PR introduces a big breaking change.
  * The doctest doesn't run but it seems like an issue on your end.

[^ns]: https://doc.rust-lang.org/reference/names/namespaces.html