### PR TITLE
Add error for cyclic query evaluations / reentrancy

### DIFF
--- a/tests/reentrancy.rs
+++ b/tests/reentrancy.rs
@@ -1,0 +1,47 @@
+use yeter::Database;
+
+#[yeter::query]
+fn a(db: &Database) -> usize {
+    *depends_on_a(db) + 1
+}
+
+#[yeter::query]
+fn depends_on_a(db: &Database) -> usize {
+    *a(db) - 1
+}
+
+// a and b depend on one another, forming a cycle
+// yeter should detect this
+
+#[test]
+#[should_panic(expected = "Cycle")]
+fn disallow() {
+    let mut db = Database::new();
+    db.register_impl::<a>();
+    db.register_impl::<depends_on_a>();
+
+    // This cannot be evaluated
+    dbg!(a(&db));
+}
+
+#[yeter::query]
+fn fib(db: &Database, idx: u64) -> u64 {
+    match idx {
+        0 => 0,
+        1 => 1,
+        idx => *fib_r(db, idx - 1) + *fib_r(db, idx - 2),
+    }
+}
+
+// FIXME remove (https://github.com/elegaanz/yeter/issues/5)
+#[inline]
+fn fib_r(db: &Database, idx: u64) -> std::rc::Rc<u64> {
+    fib(db, idx)
+}
+
+#[test]
+fn allow_if_different_input() {
+    let mut db = Database::new();
+    db.register_impl::<fib>();
+    assert_eq!(*fib(&db, 15), 610);
+}


### PR DESCRIPTION
This solution is not perfect, but should be somewhat OK for the moment

  * To handle reentrancy, queries _must_ be run with `Database::try_run` instead of "naturally" calling them. This is also true inside the "query land". This leads to uglier code.
    * This could be solved in a half-clean way by running all queries inside a panic handler, and letting the panic bubble up if `Database::run` was called instead of `try_run`.
    * We could also have the macro generate a `try_` version of each query, possibly optionally, through a special macro argument.
  * There is currently no way to know where the cyclic call happened. That said, we could argue that it is the user's responsibility to "attach" context to `CycleErrors` (and it would actually be more flexible than to impose a backtrace object).