### PR TITLE
Remove `QueryDef::PATH`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "GPL-3.0"
 
 [dependencies]
 state = "0.5"
-yeter-macros = { path = "macros", version = "0.1.0" }
+yeter-macros = { path = "macros", version = "0.4.0" }
 
 [workspace]
 members = ["macros"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yeter-macros"
-version = "0.1.0"
+version = "0.4.0"
 edition = "2021"
 license = "GPL-3.0"
 description = "Procedural macros for yeter"

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -198,7 +198,7 @@ pub fn query(
         #(#query_attrs)*
         #query_vis fn #query_name(#db_ident: &::yeter::Database, #calling_tuple_args) -> ::std::rc::Rc<#output_type> {
             use ::yeter::QueryDef;
-            #db_ident.run::<#input_type, #output_type>(#query_name::PATH, #calling_tuple)
+            #db_ident.run::<#query_name>(#calling_tuple)
         }
 
         #[allow(non_camel_case_types)]
@@ -206,7 +206,6 @@ pub fn query(
         #query_vis enum #query_name {}
 
         impl ::yeter::QueryDef for #query_name {
-            const PATH: &'static str = stringify!(#query_name);
             type Input = #input_type;
             type Output = #output_type;
         }


### PR DESCRIPTION
Simplification + perfs
Once #6 is merged, this PR will need an adjustment to `Database::try_run`'s signature to reflect the changes to `Database::run`.